### PR TITLE
add convert arg to int

### DIFF
--- a/src/cldwalker/logseq_query/datascript.cljs
+++ b/src/cldwalker/logseq_query/datascript.cljs
@@ -213,6 +213,11 @@
                args)
         {:keys [find in] :as query-map} (query-vec->map query)
         actual-args (into [] (or (seq args) (:default-args query-m)))
+        actual-args (mapv (fn [arg]
+                              (if (re-matches #"\d+" arg)
+                                (js/parseInt arg 10)
+                                arg))
+                            actual-args)
         _ (validate-args actual-args in)
         rules (get-rules-in-query query-map)
         q-args (conj actual-args rules)]


### PR DESCRIPTION
when user provides a arg in 
lq [query_name] [args]

prev behavior is to treat args as strings
now it attempts to convert to int when possible(and leaves it as it is when failed)


the change is useful when you want to have db-id as args

for example , 

```
 :lq/block-content
 {
     :query            [:find (pull ?b [*])
                        :in $ ?parent
                        :where
                        [?b :block/parent ?parent]]
     :inputs           [:parent]
 }
```

for this query i run run 
`lq block-content 1577`

previously it finds nothing because it treats 1577 as "1577"
not it finds the content because it treats 1577 properly as db/id

